### PR TITLE
Bug fix in ai_v1 to set typtext when tmax==ti

### DIFF
--- a/ai_v1.m
+++ b/ai_v1.m
@@ -56,7 +56,7 @@ end
 
 
 %Name type (A, B or C)
-if tmax>ti
+if tmax>=ti
    if ai>=12
       typetxt=('Type A');
    elseif ai<12

--- a/bpp_Res2.m
+++ b/bpp_Res2.m
@@ -1,4 +1,3 @@
-% bpp_Res2
 %% batch analysis of BP+ to give results like Sphygmocor and do reservoir and WI analysis
 %% Copyright 2019 Alun Hughes based on some original code by Kim Parker
 % Also uses xml2struct.m by W. Falkena, ASTI, TUDelft, 21-08-2010 with additional
@@ -49,8 +48,8 @@
 %% Select files
 folder_name ='C:\BPPdata\'; % standard directory changed to reflect new xml files
 % check that folder name exists and if not allows new folder to be chosen
-if ~exist('C:\BPPdata\', 'dir')
-      answer = questdlg('C:\BPPdata_new\ doesnt exist. Would you like to choose another folder?', ...
+if ~exist(folder_name, 'dir')
+      answer = questdlg(folder_name + 'doesnt exist. Would you like to choose another folder?', ...
 	'BPplus Data Folder','Yes', 'No [end]','Yes');
 % Handle response
     switch answer


### PR DESCRIPTION
`function [ai, Pi, Tfoot, Ti, Tmax, typetxt] = ai_v1(p,samplerate)` needs to set typtext to a value when tmax==ti to avoid an execution error where an output parameter is not set. 

What is the correct typtext when tmax==ti. I arbitrability add the == condition to the first test.  Alternatives would be to make the second test `elsif tmak<= ti` if Type C is more appropriate, or add  a final else and explicitly set `typetxt= '?'` or something suitable. 
```
%Name type (A, B or C)
if tmax>=ti
   if ai>=12
      typetxt=('Type A');
   elseif ai<12
      typetxt=('Type B');
   end
elseif tmax<ti
   typetxt=('Type C');
end
```